### PR TITLE
BUG: PI ID not conditional on PI having a first name field

### DIFF
--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -770,8 +770,8 @@ class PanDataSet:
                 panparPI = None
                 panparPI_firstname,panparPI_lastname = None, None
                 if(matrix.find('md:PI', self.ns) != None):
+                    panparPI_ID = self._getIDParts(matrix.find('md:PI', self.ns).get('id')).get('pi')
                     if(matrix.find('md:PI/md:firstName', self.ns) !=None):
-                        panparPI_ID = self._getIDParts(matrix.find('md:PI', self.ns).get('id')).get('pi')
                         panparPI_firstname= matrix.find('md:PI/md:firstName', self.ns).text
                     panparPI_lastname = matrix.find('md:PI/md:lastName', self.ns).text
                     panparPI_fullname = ', '.join(filter(None, [panparPI_lastname,panparPI_firstname]))


### PR DESCRIPTION
The PI ID variable was only being set when the record has a first name entry for the PI. Since the PI ID was otherwise unset, this would cause the code to fail on records where there is a PI field but no first name.

Now we extract the PI ID if there is a PI entry, regardless of whether they have a first name. This resolves the issue.