### PR TITLE
Explicitly add "supplement to" information

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Given a DOI, pangaeapy uses PANGAEA’s web services to automatically load PANGA
 ## Installation
 
 * Source code from [github](https://github.com/pangaea-data-publisher/pangaeapy)
-    * `pip install git+https://github.com/pangaea-data-publisher/pangaeapy`
+    * `git clone https://github.com/pangaea-data-publisher/pangaeapy`
+    * `cd pangaeapy/src/pangaeapy`
+    * `pip install .`
 * Wheels for Python from [PyPI](https://pypi.org/project/pangaeapy/)
     * `pip install pangaeapy`
 

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -470,6 +470,7 @@ class PanDataSet:
         self.authors=[]
         self.terms_cache = {} #temporary cache for terms
         self.terms_conn = sl.connect(os.path.join(self.module_dir,'data','terms.db'))
+        self.supplement_to = {} # If this dataset is supllementary to another publication, give that publications title and URI here.
         self.relations = [] #list of relations as given in
         try:
             sql = 'create table if not exists terms (term_id integer PRIMARY KEY, term_name text, term_json text, entry_date datetime default current_timestamp)'
@@ -1293,6 +1294,25 @@ class PanDataSet:
                             if reference.find("md:title", self.ns)!=None:
                                 reftitle = reference.find("md:title", self.ns).text
                             self.relations.append({"id":refid,"title":reftitle,"uri":refURI,"type":reftype})
+                        if xml.find("./md:citation/md:supplementTo", self.ns):
+                            suppl = xml.find("./md:citation/md:supplementTo", self.ns)
+                            suppURI = None
+                            supptitle = None
+                            suppyear = None
+                            suppid = suppl.get("id")
+                            if suppl.find("md:year", self.ns) is not None:
+                                suppyear = suppl.find("md:year", self.ns).text
+                            if suppl.find("md:title", self.ns) is not None:
+                                supptitle = suppl.find("md:title", self.ns).text
+                            if suppl.find("md:URI", self.ns) is not None:
+                                suppURI = suppl.find("md:URI", self.ns).text
+                            self.supplement_to = {
+                                "id": suppid,
+                                "title": supptitle,
+                                "uri": suppURI,
+                                "year": suppyear
+                            }
+                            
                         panXMLMatrixColumn=xml.findall("./md:matrixColumn", self.ns)
                         self._setParameters(panXMLMatrixColumn)
                         panXMLEvents=xml.findall("./md:event", self.ns)

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -1312,7 +1312,7 @@ class PanDataSet:
                                 "uri": suppURI,
                                 "year": suppyear
                             }
-                            
+
                         panXMLMatrixColumn=xml.findall("./md:matrixColumn", self.ns)
                         self._setParameters(panXMLMatrixColumn)
                         panXMLEvents=xml.findall("./md:event", self.ns)

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -1294,7 +1294,7 @@ class PanDataSet:
                             if reference.find("md:title", self.ns)!=None:
                                 reftitle = reference.find("md:title", self.ns).text
                             self.relations.append({"id":refid,"title":reftitle,"uri":refURI,"type":reftype})
-                        if xml.find("./md:citation/md:supplementTo", self.ns):
+                        if xml.find("./md:citation/md:supplementTo", self.ns) is not None:
                             suppl = xml.find("./md:citation/md:supplementTo", self.ns)
                             suppURI = None
                             supptitle = None

--- a/src/pangaeapy/setup.py
+++ b/src/pangaeapy/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pangaeapy',
-    version='1.0.15',
+    version='1.0.16',
     install_requires=['lxml>=4.9.1','requests>=2.26.0','pandas>=1.3.5','numpy>=1.21.0','netcdf4~=1.6.3'],
     packages=['pangaeapy','pangaeapy.exporter'],
     package_dir={'pangaeapy': ''},


### PR DESCRIPTION
... since up to now, the "supplement to" information was hidden in the `citation` member variable.

This is analogous to the treatment of the relations: A new member variable `supplement_to` is introduced that stores a dictionary with the most basic information about the publication the dataset is supplementary to (if there is one, of course).

E.g.,

```python
from pangaeapy.pandataset import PanDataSet

ds = PanDataSet("https://doi.pangaea.de/10.1594/PANGAEA.840556")
print(ds.supplement_to)
```

results in 

```
{'id': 'ref66567',
 'title': "Foraminiferal assemblages from a transitional tropical upwelling zone in the Golfe d'Arguin, Mauritania",
 'uri': 'https://doi.org/10.1016/j.ecss.2014.05.034',
 'year': '2014'}
```
