### PR TITLE
Add PanDataHarvester class

### DIFF
--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -1656,7 +1656,12 @@ class PanDataHarvester:
 
     def list_available_data(self):
         """List available binary data in the dataset."""
-        return list(self.dataset.data.iloc[self.data_index][self.column_name])
+        if self.data_index:
+            available_data = list(self.dataset.data.iloc[self.data_index][self.column_name])
+        else:
+            # If the list is empty return all rows
+            available_data = list(self.dataset.data[self.column_name])
+        return available_data
 
     def _file_exists(self, filename):
         """Check if a file is already in cache."""

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -1587,9 +1587,9 @@ class PanDataSet:
             return harvester.run_download()
         else:
             self.log(logging.WARNING, "Warning: No binary data available.")
-            self.log(logging.WARNING, f"The dataset will be saved as a CSV file in the default cache directory: {self.cachedir}")
+            self.log(logging.WARNING, f"The dataset will be saved as a CSV file in the cache directory: {self.cachedir}")
 
-            csv_path = os.path.join(self.cachedir, "dataset.csv")
+            csv_path = os.path.join(self.cachedir, f"{self.id}_data.csv")
             self.data.to_csv(csv_path, index=False)
             self.log(logging.WARNING, f"Dataset saved to {csv_path}")
 

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -24,6 +24,7 @@ import os
 import textwrap
 import sqlite3 as sl
 import logging, logging.handlers
+import toml
 
 import pickle
 from pangaeapy.exporter.pan_netcdf_exporter import PanNetCDFExporter
@@ -486,6 +487,9 @@ class PanDataSet:
         auto-generated ones are ignored right now.
 
     """
+    CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".config", "pangaeapy")
+    CONFIG_PATH = os.path.join(CONFIG_DIR, "config.toml")
+
     def __init__(self, id=None, paramlist=None, deleteFlag='', enable_cache=False,
                  cache_dir=None, include_data=True, expand_terms=[],
                  auth_token = None, cache_expiry_days=1):
@@ -500,14 +504,28 @@ class PanDataSet:
         # Mapping should be moved to e.g. netCDF class/module??
         #moddir = os.path.dirname(os.path.abspath(__file__))
         #self.CFmapping=pd.read_csv(moddir+'\\PANGAEA_CF_mapping.txt',delimiter='\t',index_col='ID')
-        # setting up the cache directory in the users home folder if no path is given
+
+        # Load cache directory from config file (if exists)
+        if cache_dir is None:
+            cache_dir = self._load_config()
+
+        # Default to user home directory cache if not set
         if cache_dir is None:
             homedir = os.path.expanduser("~")
-            self.cachedir = os.path.join(homedir, "pangaeapy_cache")
+            self.cache_dir = os.path.join(homedir, ".pangaeapy_cache")
         else:
-            self.cachedir = cache_dir
-        if not os.path.exists(self.cachedir):
-            os.makedirs(self.cachedir)
+            self.cache_dir = cache_dir
+
+        # Create cache directory if it doesn’t exist
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+        # Save the cache directory in config file
+        self._save_config(self.cache_dir)
+
+        # Inform the user about the config file location
+        print(f"[INFO] Cache directory set to: {self.cache_dir}")
+        print(f"[INFO] To change the cache directory permanently, edit: {self.CONFIG_PATH}")
+
         self.cache = enable_cache
         self.cache_expiry_days = cache_expiry_days
         self.isCollection = False
@@ -541,7 +559,7 @@ class PanDataSet:
         self.topotype = None
         self.authors = []
         self.terms_cache = {}  # temporary cache for terms
-        self.terms_conn = sl.connect(os.path.join(self.cachedir, "terms.db"))
+        self.terms_conn = sl.connect(os.path.join(self.cache_dir, "terms.db"))
         self.supplement_to = {}  # If this dataset is supllementary to another publication, give that publications title and URI here.
         self.relations = []  # list of relations as given in
         self.keywords = []  # list of keywords
@@ -609,6 +627,29 @@ class PanDataSet:
         else:
             # self.logging.append({'ERROR':'Dataset id missing, could not initialize PanDataSet object for: '+str(id)})
             self.log(logging.ERROR, "Dataset id missing, could not initialize PanDataSet object for: " + str(id))
+        # the binary column can have different names
+        self.column_name = next((col for col in ["Binary", "netCDF"] if col in self.data.columns), None)
+
+    def _load_config(self):
+        """Load cache directory from a JSON config file."""
+        if os.path.exists(self.CONFIG_PATH):
+            try:
+                with open(self.CONFIG_PATH, "r") as f:
+                    config = toml.load(f)
+                    return config.get("settings", {}).get("cache_dir")
+            except (json.JSONDecodeError, OSError):
+                print("[INFO]: Failed to load cache config. Using default cache path.")
+        return None
+
+    def _save_config(self, cache_dir):
+        """Save cache directory to a JSON config file."""
+        try:
+            os.makedirs(self.CONFIG_DIR, exist_ok=True)  # Ensure config directory exists
+            config = {"settings": {"cache_dir": cache_dir}}
+            with open(self.CONFIG_PATH, "w") as f:
+                toml.dump(config, f)
+        except OSError:
+            print("[Warning]: Failed to save cache config.")
 
     def log(self, level, message):
         message += " - " + str(self.doi)
@@ -618,7 +659,7 @@ class PanDataSet:
 
     def get_pickle_path(self):
         dirs = textwrap.wrap(str(self.id).zfill(8), 2)
-        dirpath = os.path.join(self.cachedir, *dirs)
+        dirpath = os.path.join(self.cache_dir, *dirs)
         try:
             os.makedirs(dirpath)
         except Exception as e:
@@ -1562,18 +1603,8 @@ class PanDataSet:
     def download(self, confirm_large=True):
         """Download binary data if available; otherwise, save dataframe as CSV."""
 
-        # ask user for custom cache dir
-        if self.cachedir == os.path.join(os.path.expanduser("~"), "pangaeapy_cache"):
-            self.log(logging.WARNING, f"Download data to cache: {self.cachedir}")
-            new_cache = input("Would you like to specify a different cache directory? (y/n): ")
-            if new_cache.lower() == 'y':
-                self.cachedir = input("Enter new cache directory path: ")
-                os.makedirs(self.cachedir, exist_ok=True)
-                self.log(logging.WARNING, f"Cache directory set to: {self.cachedir}")
-
-        # the binary column can have different names
-        self.column_name = next((col for col in ["Binary", "netCDF"] if col in self.data.columns), None)
         if self.column_name is not None:
+            print(f"Downloading files to {self.cache_dir}")
             print(f"Available files\n"
                   f"{self.data.loc[:, (self.column_name, self.column_name + ' (Size)')]}\n")
             idx = input("Please supply a list of comma separated indices of the files you wish to download (empty for all):")
@@ -1587,9 +1618,9 @@ class PanDataSet:
             return harvester.run_download()
         else:
             self.log(logging.WARNING, "Warning: No binary data available.")
-            self.log(logging.WARNING, f"The dataset will be saved as a CSV file in the cache directory: {self.cachedir}")
+            self.log(logging.WARNING, f"The dataset will be saved as a CSV file to {self.cache_dir}")
 
-            csv_path = os.path.join(self.cachedir, f"{self.id}_data.csv")
+            csv_path = os.path.join(self.cache_dir, f"{self.id}_data.csv")
             self.data.to_csv(csv_path, index=False)
             self.log(logging.WARNING, f"Dataset saved to {csv_path}")
 
@@ -1616,7 +1647,7 @@ class PanDataHarvester:
             raise ValueError("dataset must have a pandas DataFrame as 'data' attribute.")
 
         self.dataset = dataset
-        self.cache_dir = dataset.cachedir
+        self.cache_dir = dataset.cache_dir
         os.makedirs(self.cache_dir, exist_ok=True)
         self.column_name = dataset.column_name
         self.data_index = dataset.data_index

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -11,6 +11,9 @@ import json
 import time
 import datetime
 
+import aiohttp
+import asyncio
+import xarray as xr
 import requests
 import pandas as pd
 import numpy as np
@@ -1555,3 +1558,135 @@ class PanDataSet:
         # print(dwca_exporter.logging)
         self.logging.extend(dwca_exporter.logging)
         return ret
+
+    def download(self):
+        """Download binary data if available; otherwise, save dataframe as CSV."""
+        # ask user for custom cache dir
+        if self.cachedir == os.path.join(os.path.expanduser("~"), "pangaeapy_cache"):
+            self.log(logging.WARNING, f"Download data to cache: {self.cachedir}")
+            new_cache = input("Would you like to specify a different cache directory? (y/n): ")
+            if new_cache.lower() == 'y':
+                self.cachedir = input("Enter new cache directory path: ")
+                os.makedirs(self.cachedir, exist_ok=True)
+                self.log(logging.WARNING, f"Cache directory set to: {self.cachedir}")
+
+        # the binary column can have different names
+        self.column_name = next((col for col in ["Binary", "netCDF"] if col in self.data.columns), None)
+        if self.column_name is not None:
+            harvester = PanDataHarvester(self)
+            return harvester.run_download()
+        else:
+            self.log(logging.WARNING, "Warning: No binary data available.")
+            self.log(logging.WARNING, f"The dataset will be saved as a CSV file in the default cache directory: {self.cachedir}")
+
+            csv_path = os.path.join(self.cachedir, "dataset.csv")
+            self.data.to_csv(csv_path, index=False)
+            self.log(logging.WARNING, f"Dataset saved to {csv_path}")
+
+
+class PanDataHarvester:
+    """
+    Downloads binary data from the PANGAEA tape archive.
+    Main functionality to be implemented:
+    - inherit metadata from PanDataSet
+    - only available if there is at least one "Binary"/"netCDF column in PanDataSet.data
+    - user selected download
+        - list available data sets
+        - warn before big download
+        - show size of download
+    - show progress of download
+    - asynchronous download of multiple files
+    - automatic download for small files (< 50MB)
+    - ask user to confirm cache directory to permanently store files and allow for new cache directory
+    - check if files are already available in the cache either as pickle objects or in binary format
+    """
+
+    def __init__(self, dataset):
+        if not hasattr(dataset, "data") or not isinstance(dataset.data, pd.DataFrame):
+            raise ValueError("dataset must have a pandas DataFrame as 'data' attribute.")
+
+        self.dataset = dataset
+        self.cache_dir = dataset.cachedir
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.column_name = dataset.column_name
+
+
+    def list_available_data(self):
+        """List available binary data in the dataset."""
+        return self.dataset.data[self.dataset.data[self.column_name].notna()][[self.column_name]]
+
+    def _file_exists(self, filename):
+        """Check if a file is already in cache."""
+        return os.path.exists(os.path.join(self.cache_dir, filename))
+
+    async def _download_file(self, session, dataset_id, filename, max_retries=3):
+        """Download a single file asynchronously, handling 503 errors."""
+        url = f'https://download.pangaea.de/dataset/{dataset_id}/files/{filename}'
+        filepath = os.path.join(self.cache_dir, filename)
+        if self._file_exists(filename):
+            print(f"File {filename} already exists in cache. Skipping download.")
+            return filepath
+
+        attempt = 0
+        while attempt < max_retries:
+            try:
+                async with session.get(url) as response:
+                    if response.status == 503:
+                        print(f"{filename} is being retrieved from tape. Retrying in 2 minutes...")
+                        await asyncio.sleep(120)  # Wait 2 minutes before retrying
+                        attempt += 1
+                        continue
+
+                    total_size = int(response.headers.get('content-length', 0))
+                    with open(filepath, "wb") as f:
+                        async for chunk in response.content.iter_any():
+                            f.write(chunk)
+                print(f"Downloaded {filename} successfully!")
+                return filepath
+            except aiohttp.ClientResponseError as e:
+                attempt += 1
+                if attempt == max_retries:
+                    raise e
+                print(f"Error {e.status} encountered. Retrying ({attempt}/{max_retries})...")
+
+    async def download_files(self, confirm_large=True):
+        """Download all binary files asynchronously."""
+        binary_files = self.list_available_data()
+        dataset_id = self.dataset.id
+
+        async with aiohttp.ClientSession() as session:
+            tasks = []
+            for _, row in binary_files.iterrows():
+                filename = os.path.basename(row[self.column_name])
+
+                # Get file size before downloading (if possible)
+                url = f'https://download.pangaea.de/dataset/{dataset_id}/files/{filename}'
+                async with asyncio.TaskGroup() as tg:
+                    async with session.head(url) as response:
+                        size = int(response.headers.get('content-length', 0))
+
+                        # Ask confirmation for large files (>50MB)
+                        if size > 50 * 1024 * 1024 and confirm_large:
+                            confirm = input(f"{filename} is {size / (1024 * 1024):.2f} MB. Download? (y/n) ")
+                            if confirm.lower() != 'y':
+                                continue
+
+                        tasks.append(tg.create_task((self._download_file(session, dataset_id, filename))))
+
+            downloaded_files = [task.result() for task in tasks]
+
+        return [f for f in downloaded_files if f is not None]
+
+    def run_download(self):
+        """Start asynchronous file download and return datasets if applicable."""
+        downloaded_files = asyncio.run(self.download_files())
+        datasets = []
+
+        # for file in downloaded_files:
+        #     if file.endswith(".nc"):
+        #         print(f"Opening netCDF file: {file}")
+        #         ds = xr.open_dataset(file)
+        #         datasets.append(ds)
+
+        return datasets if datasets else downloaded_files
+

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -7,6 +7,8 @@ Test the PanDataSet class
 """
 import os
 import tempfile
+from xmlrpc.client import Binary
+
 from pangaeapy.pandataset import PanDataSet
 
 def test_default_cache_dir():
@@ -21,3 +23,8 @@ def test_custom_cache_dir():
         assert ds.cachedir == tmpdir
         ds.terms_conn.close()  # explicitly close the sqlite database
 
+def test_download_binary():
+    ds = PanDataSet(944101, enable_cache=True)
+    downloads = ds.download()
+    # TODO: Check if files are there and if size matches
+    # ds.data["Binary (Size)"]

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -7,24 +7,23 @@ Test the PanDataSet class
 """
 import os
 import tempfile
-from xmlrpc.client import Binary
 
 from pangaeapy.pandataset import PanDataSet
 
 def test_default_cache_dir():
     ds = PanDataSet(968912, enable_cache=True)
-    assert ds.cachedir is not None
-    assert os.path.isdir(ds.cachedir)  # Ensure the directory was created
+    assert ds.cache_dir is not None
+    assert os.path.isdir(ds.cache_dir)  # Ensure the directory was created
 
 
 def test_custom_cache_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         ds = PanDataSet(968912, enable_cache=True, cache_dir=tmpdir)
-        assert ds.cachedir == tmpdir
+        assert ds.cache_dir == tmpdir
         ds.terms_conn.close()  # explicitly close the sqlite database
 
-def test_download_binary():
-    ds = PanDataSet(944101, enable_cache=True)
-    downloads = ds.download()
+# def test_download_binary():
+    # ds = PanDataSet(944101, enable_cache=True)
+    # downloads = ds.download()
     # TODO: Check if files are there and if size matches
     # ds.data["Binary (Size)"]


### PR DESCRIPTION
This PR will add a new `download` method to `PanDataSet`, which invokes the `PanDataHarvester` class. Also a new approach to caching is implemented.

## Changes to PanDataSet

### Caching setup

- add `CONFIG_DIR` and `CONFIG_PATH` as class variables used to store the `config.toml`file, which will keep track of user specific settings such as the cache directory
- we try to load the cache directory from the config file if it is not given via `cache_dir=any/path/caching`
- if that fails the cache is set to `~/.pangaeapy_cache`
- the `cache_dir` is saved to `~/.config/pangaeapy/config.toml` (TOML is used because it is more user friendly to work with in an editor than json)
- loading and saving of the config file is done with two new internal (marked by a leading underscore) functions
- `cachedir` is renamed to `cache_dir` throughout the whole module

### Prerequisits for downloading binary data

- add attribute `column_name` which is set by searching for either "Binary" or "netCDF" in the column names of the data table
- will be set to None if these two terms cannot be found in the data table column names

### `download` method

The new `download` method uses the `column_name` attribute to check if the data set has binary data or not.

**No binary data**: Save the data table to a csv file in the cache directory

**Binary data**: 
- List the available binary files and their size
- Ask the user for a list of indices to download, which correspond to the available files (empty for all)
- Check for out of range indices
- Invoke the PanDataHarvester

## PanDataHarvester

Use the asyncio module to asynchronisly download all the binary files requested by the user. Skip files which already exist in the cache. This check is only done by filename.

The class has basically one method `run_download`, which is called by `PanDataSet.download()`. This first checks, if there are any active async loops, as would be the case in a jupyter notebook and then executes the `download_files` method.

There an aiohttp.ClientSession is started, which then loops through all provided filenames and downloads them by creating a new task with the `_download_file` method. For files larger 50Mb it asks for user confirmation.

`_download_file` first checks if the filepath already exists and then tries to download the file. Since binary files are stored on tape at PANGAEA, it expects a 503 response, which means the file is being retrieved from the tape. In this case it waits 2 minutes to start the download. If two minutes were not enough the resulting error is caught and another attempt is made. This is also communicated to the user. A maximum of 3 retries are attempted before exiting with an error.

After all downloads are finished a list with the downloaded filenames is returned by `run_download`.

## Further improvements

- [ ] clean up code
- [ ] improve structure of `PanDataHarvester`
- [ ] add more precice documentation
- [ ] add functionality to resume downloads on incomplete files -> file exists check should consider size
- [ ] use the returned list of downloaded filenames to asynchronisly open the netcdf files and return a list of xarray data sets instead of the list of downloaded filenames
- [ ] add tests



