### PR TITLE
Update download function

### DIFF
--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -1600,7 +1600,7 @@ class PanDataSet:
         self.logging.extend(dwca_exporter.logging)
         return ret
 
-    def download(self, interactive: bool = False, confirm_large: bool = True):
+    def download(self, interactive: bool = False, confirm_large: bool = False):
         """Download binary data if available; otherwise, save dataframe as CSV.
 
         When exploring data sets for the first time it is recommended to set interactive to True.

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -1601,7 +1601,12 @@ class PanDataSet:
         return ret
 
     def download(self, confirm_large=True):
-        """Download binary data if available; otherwise, save dataframe as CSV."""
+        """Download binary data if available; otherwise, save dataframe as CSV.
+
+        Returns
+        -------
+            List of downloaded or saved filenames
+        """
 
         if self.column_name is not None:
             print(f"Downloading files to {self.cache_dir}")
@@ -1622,7 +1627,8 @@ class PanDataSet:
 
             csv_path = os.path.join(self.cache_dir, f"{self.id}_data.csv")
             self.data.to_csv(csv_path, index=False)
-            self.log(logging.WARNING, f"Dataset saved to {csv_path}")
+            print(f"Dataset saved to {csv_path}")
+            return [csv_path]
 
 
 class PanDataHarvester:
@@ -1751,12 +1757,5 @@ class PanDataHarvester:
             # No running event loop, create a new one
             downloaded_files = asyncio.run(self.download_files())
 
-        datasets = []
-        for file in downloaded_files:
-            if file.endswith(".nc"):
-                print(f"Opening netCDF file: {file}")
-                ds = xr.open_dataset(file)
-                datasets.append(ds)
-
-        return downloaded_files, datasets if datasets else downloaded_files
+        return downloaded_files
 

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -7,7 +7,8 @@ Test the PanDataSet class
 """
 import os
 from pangaeapy.pandataset import PanDataSet
-import xarray as xr
+import pytest
+
 
 def test_default_cache_dir():
     ds = PanDataSet(968912, enable_cache=True)
@@ -20,10 +21,15 @@ def test_custom_cache_dir(tmp_path):
     assert ds.cache_dir == tmp_path
     ds.terms_conn.close()  # explicitly close the sqlite database
 
-def test_netcdf_download(monkeypatch):
-    # Simulate user input
-    monkeypatch.setattr('builtins.input', lambda _: '1,2,4')
+
+@pytest.mark.parametrize("interactive", [True, False])
+def test_netcdf_download(monkeypatch, interactive):
+    # simulate user input only when interactive is True
+    if interactive:
+        monkeypatch.setattr('builtins.input', lambda _: '1,2,4')
+
     ds = PanDataSet(944101, enable_cache=True)
-    filenames = ds.download()
+    filenames = ds.download(interactive=interactive)
+
     for filename in filenames:
         assert os.path.isfile(filename)  # check if file was downloaded

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -24,7 +24,6 @@ def test_netcdf_download(monkeypatch):
     # Simulate user input
     monkeypatch.setattr('builtins.input', lambda _: '1,2,4')
     ds = PanDataSet(944101, enable_cache=True)
-    filenames, downloads = ds.download()
-    for filename, download in zip(filenames, downloads):
+    filenames = ds.download()
+    for filename in filenames:
         assert os.path.isfile(filename)  # check if file was downloaded
-        assert type(download) == xr.Dataset


### PR DESCRIPTION
A download function should just do this. Download files. To enable users to have this in a script the interactivity of the function is now hidden behind the arguments `interactive` and `confirm_large`. 
Thus, when calling the function all available data files will be downloaded no matter the size.

The docstring warns the user about this and suggest different behaviour, when exploring the data set.