### PR TITLE
Optimize download

### DIFF
--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -1597,7 +1597,8 @@ class PanDataSet:
         self.logging.extend(dwca_exporter.logging)
         return ret
 
-    def download(self, interactive: bool = False, confirm_large: bool = False):
+    def download(self, interactive: bool = False, confirm_large: bool = False,
+                 indices: list = None, columns: list[str] = None):
         """Download binary data if available; otherwise, save dataframe as CSV.
 
         When exploring data sets for the first time it is recommended to set interactive to True.
@@ -1611,6 +1612,10 @@ class PanDataSet:
             Default is to download all files.
         confirm_large : bool
             Ask for permission before downloading files larger than 50Mb.
+        indices : list
+            Row indices of the data to download (e.g. [1, 2, 6]).
+        columns : list of strings
+            Column names of the data to download (e.g. ["Binary", "netCDF"]).
 
         Returns
         -------
@@ -1660,8 +1665,8 @@ class PanDataSet:
                     raise ValueError("Index out of range")
 
             else:
-                self.columns = column_names
-                self.data_index = []
+                self.columns = columns if columns else column_names
+                self.data_index = indices if indices else []
 
             harvester = PanDataHarvester(self, confirm_large=confirm_large)
             return harvester.run_download()

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -46,15 +46,3 @@ def test_netcdf_download(monkeypatch, interactive, test_input):
 
     for filename in filenames:
         assert os.path.isfile(filename)  # check if file was downloaded
-
-
-
-# ds_id = 870454  # no data
-# ds_id = 974108  # multiple netCDF columns
-# ds_id = 971624  # normal dataset
-# ds_id = 956151  # Binary + Binary (Size)
-# ds_id = 944101  # netCDF file
-# ds_id = 823321  # many small files but URL column
-# ds_id = 968896  # many small netCDF file
-# self = PanDataSet(ds_id, enable_cache=True)
-# self.download(interactive=True)

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -25,6 +25,7 @@ def test_custom_cache_dir(tmp_path):
 @pytest.mark.parametrize("interactive, test_input", [
     (True, ("", "")),
     (True, ("Binary", "1,3, 4,  5")),
+    (True, ("Binary", "1-3, 5")),
     (False, None)
 ])
 def test_netcdf_download(monkeypatch, interactive, test_input):

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -24,9 +24,9 @@ def test_custom_cache_dir(tmp_path):
 
 @pytest.mark.parametrize("interactive, test_input", [
     (True, ("", "")),
-    (True, ("Binary", "1,3, 4,  5")),
+    (True, ("Binary", "1,3, 2,  5")),
     (True, ("Binary", "1-3, 5")),
-    (False, None)
+    (False, (None, None))
 ])
 def test_netcdf_download(monkeypatch, interactive, test_input):
     # simulate user input only when interactive is True
@@ -37,5 +37,24 @@ def test_netcdf_download(monkeypatch, interactive, test_input):
     ds = PanDataSet(944101, enable_cache=True)
     filenames = ds.download(interactive=interactive)
 
+    # check if the user input was parsed correctly
+    if any(test_input):
+        assert ds.data_index == [1, 2, 3, 5]
+        # the data set only has this column so this test is useless
+        # keep it and find a better test data set
+        assert ds.columns == ["Binary"]
+
     for filename in filenames:
         assert os.path.isfile(filename)  # check if file was downloaded
+
+
+
+# ds_id = 870454  # no data
+# ds_id = 974108  # multiple netCDF columns
+# ds_id = 971624  # normal dataset
+# ds_id = 956151  # Binary + Binary (Size)
+# ds_id = 944101  # netCDF file
+# ds_id = 823321  # many small files but URL column
+# ds_id = 968896  # many small netCDF file
+# self = PanDataSet(ds_id, enable_cache=True)
+# self.download(interactive=True)


### PR DESCRIPTION
Main improvements:
- allow only 5 parallel requests to the server using asyncio.Semaphore
- add indices and columns as keyword arguments to download (still needs testing) -> can be used to skip interactive mode but still only download a subset of data
- big restructure of the asyncio task creation
- handle response status 429 (too many connections) -> should not be needed due to the semaphore approach but we never know...