### PR TITLE
Add get_doi() to PanQuery

### DIFF
--- a/src/pangaeapy/panquery.py
+++ b/src/pangaeapy/panquery.py
@@ -1,7 +1,7 @@
 import logging
 import re
-
 import requests
+import warnings
 
 logger = logging.getLogger("panquery")
 
@@ -88,6 +88,11 @@ class PanQuery:
             result["position"] = offset + i
         self.result = results
 
-    def get_doi(self):
-        """Return list of DOIs of search results."""
-        return [r["URI"] for r in self.result]
+    def get_dois(self) -> list:
+        """Return list of DOIs or URLs of search results.
+        Warn user if not all search results have a DOI.
+        """
+        dois = [r["URI"] for r in self.result]
+        if not all([d.startswith("doi:") for d in dois]) and dois != []:
+            warnings.warn("Not all returned data sets have a DOI. Returning the URI instead.", UserWarning)
+        return dois

--- a/src/pangaeapy/panquery.py
+++ b/src/pangaeapy/panquery.py
@@ -87,3 +87,7 @@ class PanQuery:
                 result["type"] = "member"
             result["position"] = offset + i
         self.result = results
+
+    def get_doi(self):
+        """Return list of DOIs of search results."""
+        return [r["URI"] for r in self.result]

--- a/test/test_PanQuery.py
+++ b/test/test_PanQuery.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""
+Test the PanQuery class
+"""
+
+from pangaeapy import PanQuery
+
+def test_get_doi():
+    """Test the correct retrieval of DOIs from the search result."""
+    dois = ["doi:10.1594/PANGAEA.956151", "doi:10.1594/PANGAEA.956156"]
+    query = " or ".join(dois)
+    result = PanQuery(query)
+    doi_retrieved = result.get_doi()
+    assert all([doi in doi_retrieved for doi in dois])

--- a/test/test_PanQuery.py
+++ b/test/test_PanQuery.py
@@ -5,10 +5,10 @@ Test the PanQuery class
 
 from pangaeapy import PanQuery
 
-def test_get_doi():
+def test_get_dois():
     """Test the correct retrieval of DOIs from the search result."""
     dois = ["doi:10.1594/PANGAEA.956151", "doi:10.1594/PANGAEA.956156"]
     query = " or ".join(dois)
     result = PanQuery(query)
-    doi_retrieved = result.get_doi()
+    doi_retrieved = result.get_dois()
     assert all([doi in doi_retrieved for doi in dois])


### PR DESCRIPTION
Adds a small convenience function to PanQuery to get a list of DOIs from the search result.