### PR TITLE
Handle URLs in the binary column correctly

### DIFF
--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -68,3 +68,10 @@ def test_download_kwargs(tmp_path, indices, columns, expected_exception):
         filenames = ds.download(indices=indices, columns=columns)
         assert all(os.path.isfile(f) for f in filenames), \
             "All expected files should be created"
+
+
+def test_download_url_handling():
+    """Some data sets provide a full download URL in the URL field"""
+    ds = PanDataSet(896710, enable_cache=True)
+    filename = ds.download(indices=[0])
+    assert os.path.isfile(filename[0])


### PR DESCRIPTION
Some binary data sets list the download link in the binary column instead of a simple filename. Thus, we can just use this download link instead of constructing one.

Parse the url and extract the actual filename in this case as well to save the data to the correct local filename.

The test checks if the file is correctly downloaded.