### PR TITLE
Add download of zip file

### DIFF
--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -491,7 +491,7 @@ class PanDataSet:
     """
     CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".config", "pangaeapy")
     CONFIG_PATH = os.path.join(CONFIG_DIR, "config.toml")
-
+    #TODO: set enable cache to True
     def __init__(self, id=None, paramlist=None, deleteFlag='', enable_cache=False,
                  cache_dir=None, include_data=True, expand_terms=[],
                  auth_token=None, cache_expiry_days=1):
@@ -596,14 +596,14 @@ class PanDataSet:
         #self.logger.info('Test')
         self.quality_flags={'ok':'valid','?':'questionable','/':'not_valid','*':'unknown'}
         self.quality_flag_replace={'ok':0,'?':1,'/':2,'*':3}
-        if self.id != None:
-            gotData=False
+        if self.id is not None:
+            gotData = False
 
             if self.cache:
                 # self.logging.append({'INFO':'Caching activated..trying to load data and metadata from cache'})
                 self.log(logging.INFO, "Caching activated..trying to load data and metadata from cache")
                 if self.check_pickle():
-                    gotData=self.from_pickle()
+                    gotData = self.from_pickle()
                 else:
                     self.drop_pickle()
                     gotData = False
@@ -1048,11 +1048,10 @@ class PanDataSet:
         This method populates the data DataFrame with data from a PANGAEA dataset.
         In addition to the data given in the tabular ASCII file delivered by PANGAEA.
 
-
         Parameters:
         -----------
         addEventColumns : boolean
-            In case Latitude, Longititude, Elevation, Date/Time and Event are not given in the ASCII matrix, which sometimes is possible in single Event datasets,
+            In case Latitude, Longitude, Elevation, Date/Time and Event are not given in the ASCII matrix, which sometimes is possible in single Event datasets,
             the setData could add these columns to the dataframe using the information given in the metadata for Event. Default is 'True'
 
         """
@@ -1640,7 +1639,7 @@ class PanDataSet:
         column_names = self.data.filter(regex=pattern).columns.tolist()
 
         if column_names:
-            print(f"Downloading files to {self.cache_dir}")
+            self.log(logging.INFO, f"Downloading files to {self.cache_dir}")
             if interactive:
                 # do not truncate any columns
                 with pd.option_context('display.max_columns', None, 'display.width', None):
@@ -1865,6 +1864,7 @@ class PanDataHarvester:
         url = f"https://download.pangaea.de/dataset/{self.id}/allfiles.zip"
         zip_path = Path(self.cache_dir) / "allfiles.zip"
         extract_dir = Path(self.cache_dir)
+        #TODO: use dynamic version
         url_headers = {
             "Authorization": f"Bearer {self.auth_token}",
             "User-Agent": "pangaeapy/1.0.22"

--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -5,15 +5,54 @@
 
 Test the PanDataSet class
 """
+import io
 import os
-from pangaeapy.pandataset import PanDataSet
+import pandas as pd
+from pangaeapy.pandataset import PanDataSet, PanDataHarvester
 import pytest
+import re
+import zipfile
 
 
-def test_default_cache_dir():
+# needed for the zip download test
+@pytest.fixture
+def make_fake_zip_bytes(filenames):
+    # Create a zip file in memory with the given filenames
+    mem_zip = io.BytesIO()
+    with zipfile.ZipFile(mem_zip, 'w') as zf:
+        for fname in filenames:
+            zf.writestr(fname, "dummy data")
+    mem_zip.seek(0)
+    return mem_zip.read()
+
+
+@pytest.fixture
+def filenames():
+    return [f"filename_{x}.nc" for x in range(11)]
+
+
+@pytest.fixture
+def mock_pandataset(mocker, tmp_path, filenames):
+    dataset = mocker.Mock()
+    dataset.id = "123456"
+    dataset.auth_token = None
+    dataset.data = pd.DataFrame({"Binary": filenames})
+    dataset.cache_dir = tmp_path / "cache"
+    # os.makedirs(dataset.cache_dir, exist_ok=True)
+    dataset.columns = ["Binary"]
+    dataset.data_index = []
+    dataset.confirm_large = True
+    # dataset.semaphore = asyncio.Semaphore(5)  # Limit concurrent downloads
+    return dataset
+
+
+def test_default_cache_dir(mocker):
+    mock_makedirs = mocker.patch("os.makedirs")
     ds = PanDataSet(968912, enable_cache=True)
-    assert ds.cache_dir is not None
-    assert os.path.isdir(ds.cache_dir)  # Ensure the directory was created
+    expected_default = os.path.join(os.path.expanduser("~"), ".pangaeapy_cache")
+    assert ds.cache_dir == expected_default
+    # Ensure PanDataSet tried to create the directory
+    mock_makedirs.assert_any_call(expected_default, exist_ok=True)
 
 
 def test_custom_cache_dir(tmp_path):
@@ -75,3 +114,67 @@ def test_download_url_handling():
     ds = PanDataSet(896710, enable_cache=True)
     filename = ds.download(indices=[0])
     assert os.path.isfile(filename[0])
+
+
+class TestPanDataHarvester:
+    """Test the download functionality of pangaeapy"""
+
+    @pytest.mark.parametrize(
+        "auth_token, status_code, expected_error",
+        [
+            (None, 401, "401 Client Error: Unauthorized access."),
+            ("valid_token", 200, None)
+        ],
+        ids=["invalid_token", "valid_token"]
+    )
+    def test_download_zip_file(
+            self, mocker, mock_pandataset, requests_mock, capsys, filenames, auth_token, status_code, expected_error
+    ):
+        """Test the download of complete binary data sets via the zip download link"""
+
+        class FakeZipFile:
+            # fake zip file, which should be downloaded when a valid token is given and self.data_index is []
+            def __init__(self, file, mode='r'):
+                self.file = file
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            def namelist(self):
+                return filenames
+
+            def extractall(self, path):
+                pass  # do nothing
+
+        ds = mock_pandataset
+        ds.auth_token = auth_token  # Set token for this test case
+
+        # mock up http response
+        matcher = re.compile(r"https://download\.pangaea\.de/dataset/\d+/allfiles\.zip")
+        requests_mock.get(matcher, status_code=status_code)
+
+        # patch the ZipFile class
+        mocker.patch("zipfile.ZipFile", side_effect=FakeZipFile)
+
+        # Mock os.remove to avoid deleting real files
+        mocker.patch("os.remove")
+
+        # initiate the harvester with the mock_pandataset
+        harvester = PanDataHarvester(ds, confirm_large=True)
+        result = harvester.run_download()
+        # capture console output
+        captured = capsys.readouterr()
+
+        # handle the two test cases
+        if expected_error:
+            assert expected_error in captured.out
+            assert result == []
+        else:
+            # Build expected filepaths
+            expected_filepaths = [
+                os.path.join(ds.cache_dir, fname) for fname in filenames
+            ]
+            assert result == expected_filepaths


### PR DESCRIPTION
PANGAEA offers an easy way to download all binary files of a binary data set via a ZIP link. However, a valid auth_token (called Bearer Token on the website) is needed for that.

The advantage of the ZIP link is that the tape archive optimizes the file retrieval and only one http request is needed.

 A further improvement is that pangaeapy now passes itself as the User-Agent inside the http request. This should make it easier for PANGAEA to track access to their database.

 Note that binary data sets with a URL column do not offer this ZIP download.

 If the user does not open the data set with a valid auth_token, we return a descriptive error.
