### PR TITLE
Remove interactive download functionality

### DIFF
--- a/test/test_PanDataSet.py
+++ b/test/test_PanDataSet.py
@@ -41,7 +41,6 @@ def mock_pandataset(mocker, tmp_path, filenames):
     # os.makedirs(dataset.cache_dir, exist_ok=True)
     dataset.columns = ["Binary"]
     dataset.data_index = []
-    dataset.confirm_large = True
     # dataset.semaphore = asyncio.Semaphore(5)  # Limit concurrent downloads
     return dataset
 
@@ -59,32 +58,6 @@ def test_custom_cache_dir(tmp_path):
     ds = PanDataSet(968912, enable_cache=True, cache_dir=tmp_path)
     assert ds.cache_dir == tmp_path
     ds.terms_conn.close()  # explicitly close the sqlite database
-
-
-@pytest.mark.parametrize("interactive, test_input", [
-    (True, ("", "")),
-    (True, ("Binary", "1,3, 2,  5")),
-    (True, ("Binary", "1-3, 5")),
-    (False, (None, None))
-])
-def test_netcdf_download(monkeypatch, interactive, test_input):
-    # simulate user input only when interactive is True
-    if interactive:
-        inputs = iter(test_input)
-        monkeypatch.setattr('builtins.input', lambda _: next(inputs))
-
-    ds = PanDataSet(944101, enable_cache=True)
-    filenames = ds.download(interactive=interactive)
-
-    # check if the user input was parsed correctly
-    if any(test_input):
-        assert ds.data_index == [1, 2, 3, 5]
-        # the data set only has this column so this test is useless
-        # keep it and find a better test data set
-        assert ds.columns == ["Binary"]
-
-    for filename in filenames:
-        assert os.path.isfile(filename)  # check if file was downloaded
 
 
 @pytest.mark.parametrize(
@@ -163,7 +136,7 @@ class TestPanDataHarvester:
         mocker.patch("os.remove")
 
         # initiate the harvester with the mock_pandataset
-        harvester = PanDataHarvester(ds, confirm_large=True)
+        harvester = PanDataHarvester(ds)
         result = harvester.run_download()
         # capture console output
         captured = capsys.readouterr()


### PR DESCRIPTION
Interactivity is not really a use case for pangaeapy as it is mainly used to automate data set access.

Thus, the interactive part is removed.

- remove confirm_large keyword
- remove interactive keyword

Further changes:
- Include explicit None returns
- run_download: check for 'URL' in all column names

Changes in tests:
- remove interactive test
- remove confirm_large keyword