### PR TITLE
Improve directory creation for pickle path in PanDataSet

### DIFF
--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -690,7 +690,7 @@ class PanDataSet:
                 pickle_path.parent.mkdir(parents=True)
             except Exception as e:
                 pass
-            with open(self.get_pickle_path(), "wb") as f:
+            with open(pickle_path, "wb") as f:
                 pickle.dump(state, f, 2)
             # self.logging.append({'INFO': 'Saved cache (pickle) file at: ' + str(self.get_pickle_path())})
             self.log(logging.INFO, "Saved cache (pickle) file at: " + str(self.get_pickle_path()))

--- a/src/pangaeapy/pandataset.py
+++ b/src/pangaeapy/pandataset.py
@@ -612,10 +612,6 @@ class PanDataSet:
     def get_pickle_path(self):
         dirs = textwrap.wrap(str(self.id).zfill(8), 2)
         dirpath = Path(self.cachedir, *dirs)
-        try:
-            dirpath.mkdir(parents=True)
-        except Exception as e:
-            pass
         return Path(dirpath, str(self.id) + "_data.pik")
 
     def check_pickle(self):
@@ -689,6 +685,11 @@ class PanDataSet:
         if not self.data.empty:
             state = self.__dict__.copy()
             del state["terms_conn"]
+            pickle_path = self.get_pickle_path()
+            try:
+                pickle_path.parent.mkdir(parents=True)
+            except Exception as e:
+                pass
             with open(self.get_pickle_path(), "wb") as f:
                 pickle.dump(state, f, 2)
             # self.logging.append({'INFO': 'Saved cache (pickle) file at: ' + str(self.get_pickle_path())})


### PR DESCRIPTION
This pull request updates the logic for creating directories when saving pickle files in the `pandataset.py` module. 

The main change is to move the directory creation responsibility from the `get_pickle_path` method to the `to_pickle` method, ensuring directories are only created when actually saving a pickle file.

The main reason I think this is viable is, that even when pickling is disabled (which it is by default) the pickle directory still gets created, thereby cluttering the workspace unnecessarily.